### PR TITLE
Use shared constant for day count

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,6 @@
 'use client';  // Indica que este componente solo debe ejecutarse en el cliente
 import { useState, useEffect } from 'react';
+import { DAYS_COUNT } from '@/lib/constants';
 
 // Componente para mostrar el progreso del calendario
 const CalendarOverview = () => {
@@ -13,7 +14,7 @@ const CalendarOverview = () => {
         const days = JSON.parse(savedDays);
         const completed = days.filter(day => day.completed).length;
         setCompletedDays(completed);
-        setRemainingDays(90 - completed);
+        setRemainingDays(DAYS_COUNT - completed);
       }
     }
   }, []);

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
+import { DAYS_COUNT } from '@/lib/constants';
 
 // Ejercicios con series y repeticiones para cada grupo muscular
 const ejerciciosPorGrupo = {
@@ -46,7 +47,7 @@ const ejerciciosPorGrupo = {
 const Calendar = () => {
   const [selectedDay, setSelectedDay] = useState(null);
   const [days, setDays] = useState(() =>
-    new Array(90).fill({
+    new Array(DAYS_COUNT).fill({
       completed: false,
       restDay: false,
       exercisesCompleted: [],
@@ -131,7 +132,7 @@ const Calendar = () => {
   };
 
   const handleResetProgress = () => {
-    const resetDays = new Array(90).fill({
+    const resetDays = new Array(DAYS_COUNT).fill({
       completed: false,
       restDay: false,
       exercisesCompleted: [],
@@ -198,7 +199,7 @@ const Calendar = () => {
 
   return (
     <div style={containerStyle}>
-      <h2 style={headerStyle}>Calendario de 90 días</h2>
+      <h2 style={headerStyle}>Calendario de {DAYS_COUNT} días</h2>
       <div style={gridStyle}>
         {days.map((day, index) => (
           <div

--- a/src/components/DietProgress.js
+++ b/src/components/DietProgress.js
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
+import { DAYS_COUNT } from '@/lib/constants';
 import { Pie } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 
@@ -9,7 +10,7 @@ const DietProgress = () => {
   const [selectedDay, setSelectedDay] = useState(null);
   const [fastingHours, setFastingHours] = useState('');
   const [days, setDays] = useState(() =>
-    new Array(90).fill({
+    new Array(DAYS_COUNT).fill({
       dietCompleted: false,
       fastingHours: '',
     })
@@ -107,7 +108,7 @@ const DietProgress = () => {
   };
 
   const handleResetProgress = () => {
-    const resetDays = new Array(90).fill({
+    const resetDays = new Array(DAYS_COUNT).fill({
       dietCompleted: false,
       fastingHours: '',
     });
@@ -127,7 +128,7 @@ const DietProgress = () => {
     labels: ['Días cumplidos', 'Días restantes'],
     datasets: [
       {
-        data: [completedDays, 90 - completedDays],
+        data: [completedDays, DAYS_COUNT - completedDays],
         backgroundColor: ['#4caf50', '#e0e0e0'],
         hoverBackgroundColor: ['#66bb6a', '#bdbdbd'],
         borderColor: '#fff',
@@ -287,7 +288,7 @@ const DietProgress = () => {
       )}
 
       <div style={{ marginTop: '30px' }}>
-        <h4>Días cumplidos: {completedDays} / 90</h4>
+        <h4>Días cumplidos: {completedDays} / {DAYS_COUNT}</h4>
         <h4>Porcentaje de avance: {dietProgressPercentage}%</h4>
         <h4>Horas de ayuno promedio: {averageFastingHours} hrs</h4>
       </div>

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,1 @@
+export const DAYS_COUNT = 90;


### PR DESCRIPTION
## Summary
- add `DAYS_COUNT` constant
- use constant in home page state calc
- update calendar to use constant
- refactor diet progress to use constant

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848c7575a60832f90390802c64cb6d6