### PR TITLE
Use Array.from for initializing day arrays

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -46,12 +46,12 @@ const ejerciciosPorGrupo = {
 const Calendar = () => {
   const [selectedDay, setSelectedDay] = useState(null);
   const [days, setDays] = useState(() =>
-    new Array(90).fill({
+    Array.from({ length: 90 }, () => ({
       completed: false,
       restDay: false,
       exercisesCompleted: [],
       muscleGroup: '',
-    })
+    }))
   );
 
   // Cargar datos desde localStorage cuando el componente está montado
@@ -80,9 +80,10 @@ const Calendar = () => {
         const currentDay = { ...updatedDays[selectedDay] };
 
         currentDay.muscleGroup = group;
-        currentDay.exercisesCompleted = new Array(
-          ejerciciosPorGrupo[group].length
-        ).fill(false);
+        currentDay.exercisesCompleted = Array.from(
+          { length: ejerciciosPorGrupo[group].length },
+          () => false
+        );
 
         updatedDays[selectedDay] = currentDay;
         return updatedDays;
@@ -131,12 +132,12 @@ const Calendar = () => {
   };
 
   const handleResetProgress = () => {
-    const resetDays = new Array(90).fill({
+    const resetDays = Array.from({ length: 90 }, () => ({
       completed: false,
       restDay: false,
       exercisesCompleted: [],
       muscleGroup: '',
-    });
+    }));
     setDays(resetDays);
     localStorage.removeItem('days');
     setSelectedDay(null);

--- a/src/components/DietProgress.js
+++ b/src/components/DietProgress.js
@@ -9,10 +9,10 @@ const DietProgress = () => {
   const [selectedDay, setSelectedDay] = useState(null);
   const [fastingHours, setFastingHours] = useState('');
   const [days, setDays] = useState(() =>
-    new Array(90).fill({
+    Array.from({ length: 90 }, () => ({
       dietCompleted: false,
       fastingHours: '',
-    })
+    }))
   );
 
   // Variables para calculadora BMR y macros
@@ -107,10 +107,10 @@ const DietProgress = () => {
   };
 
   const handleResetProgress = () => {
-    const resetDays = new Array(90).fill({
+    const resetDays = Array.from({ length: 90 }, () => ({
       dietCompleted: false,
       fastingHours: '',
-    });
+    }));
     setDays(resetDays);
     localStorage.removeItem('days');
     setSelectedDay(null);


### PR DESCRIPTION
## Summary
- refactor initialization for 90-day arrays in `Calendar.js` and `DietProgress.js`
- update reset functionality to create fresh objects
- use `Array.from` when setting completed-exercises array

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_684888f8ed28832f87197d18556b4644