### PR TITLE
Add ChatGPT routine generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key
+DATABASE_URL="file:./dev.db"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "jamfit-app",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^6.9.0",
         "chart.js": "^4.4.4",
         "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",
         "next": "14.2.13",
+        "openai": "^5.3.0",
+        "prisma": "^6.9.0",
         "react": "^18",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18",
@@ -236,6 +239,82 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/fetch-engine": "6.9.0",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0"
       }
     },
     "node_modules/@swc/counter": {
@@ -853,6 +932,15 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1035,6 +1123,27 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/openai": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
+      "integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1155,6 +1264,31 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/prisma": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.9.0",
+        "@prisma/engines": "6.9.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@prisma/client": "^6.9.0",
     "chart.js": "^4.4.4",
     "cross-env": "^7.0.3",
     "css-loader": "^7.1.2",
     "next": "14.2.13",
+    "openai": "^5.3.0",
+    "prisma": "^6.9.0",
     "react": "^18",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,15 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Routine {
+  id         Int      @id @default(autoincrement())
+  userId     String
+  description String
+  createdAt  DateTime @default(now())
+}

--- a/src/app/routines/page.js
+++ b/src/app/routines/page.js
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function RoutinesPage() {
+  const [prompt, setPrompt] = useState('');
+  const [routine, setRoutine] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [routines, setRoutines] = useState([]);
+
+  const loadRoutines = async () => {
+    const res = await fetch('/api/generateRoutine');
+    if (res.ok) {
+      setRoutines(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    loadRoutines();
+  }, []);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setRoutine('');
+    const res = await fetch('/api/generateRoutine', {
+      method: 'POST',
+      body: JSON.stringify({ prompt }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setRoutine(data.description);
+      loadRoutines();
+    } else {
+      alert(data.error || 'Error');
+    }
+    setLoading(false);
+  };
+
+  const containerStyle = {
+    padding: '20px',
+    backgroundColor: '#f0f0f0',
+    borderRadius: '15px',
+    margin: 'auto',
+    textAlign: 'center',
+    maxWidth: '1000px',
+  };
+
+  const headerStyle = {
+    fontSize: '24px',
+    fontWeight: 'bold',
+    marginBottom: '20px',
+  };
+
+  const buttonStyle = {
+    backgroundColor: '#0288d1',
+    color: '#fff',
+    padding: '12px',
+    borderRadius: '8px',
+    border: 'none',
+    cursor: 'pointer',
+    margin: '10px 5px',
+  };
+
+  return (
+    <div style={containerStyle}>
+      <h2 style={headerStyle}>Rutinas</h2>
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Describe tus objetivos"
+        style={{ width: '100%', minHeight: '80px', marginBottom: '10px' }}
+      />
+      <br />
+      <button onClick={handleGenerate} style={buttonStyle} disabled={loading}>
+        {loading ? 'Generando...' : 'Generar Rutina'}
+      </button>
+
+      {routine && (
+        <div style={{ textAlign: 'left', marginTop: '20px' }}>
+          <h3>Rutina generada</h3>
+          <pre>{routine}</pre>
+        </div>
+      )}
+
+      <div style={{ textAlign: 'left', marginTop: '20px' }}>
+        <h3>Rutinas guardadas</h3>
+        <ul>
+          {routines.map((r) => (
+            <li key={r.id}>{r.description}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/prisma.js
+++ b/src/lib/prisma.js
@@ -1,0 +1,6 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global;
+const prisma = globalForPrisma.prisma || new PrismaClient();
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+export default prisma;

--- a/src/pages/api/generateRoutine.js
+++ b/src/pages/api/generateRoutine.js
@@ -1,0 +1,43 @@
+import { Configuration, OpenAIApi } from 'openai';
+import prisma from '../../lib/prisma';
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const routines = await prisma.routine.findMany({ orderBy: { createdAt: 'desc' } });
+    return res.status(200).json(routines);
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { prompt, userId } = JSON.parse(req.body || '{}');
+
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt required' });
+  }
+
+  const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+  const openai = new OpenAIApi(configuration);
+
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = completion.choices[0].message.content.trim();
+
+    const saved = await prisma.routine.create({
+      data: {
+        userId: userId || 'anonymous',
+        description: text,
+      },
+    });
+
+    return res.status(200).json(saved);
+  } catch (error) {
+    console.error('Error generating routine', error);
+    return res.status(500).json({ error: 'Failed to generate routine' });
+  }
+}


### PR DESCRIPTION
## Summary
- install `openai`, `prisma`, and `@prisma/client`
- define Prisma schema and add example env file
- implement API route to generate and store routines via ChatGPT
- add Prisma client helper
- add new `/routines` page for generating routines
- fix prisma path in `generateRoutine` API

## Testing
- `npm run lint` *(fails: prompts to set up ESLint)*
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_6848f5f8ed8c832fb3bb7e088e71cc0b