### PR TITLE
Add parallax sections with animated content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^18",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18",
+        "react-icons": "^5.5.0",
         "style-loader": "^4.0.0"
       },
       "devDependencies": {
@@ -4648,6 +4649,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^18",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18",
+    "react-icons": "^5.5.0",
     "style-loader": "^4.0.0"
   },
   "devDependencies": {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,8 @@
 'use client';  // Indica que este componente solo debe ejecutarse en el cliente
 import { useState, useEffect } from 'react';
+import QuienesSomos from '../components/QuienesSomos';
+import CoreBusiness from '../components/CoreBusiness';
+import PropuestaValor from '../components/PropuestaValor';
 
 // Componente para mostrar el progreso del calendario
 const CalendarOverview = () => {
@@ -117,13 +120,18 @@ const HomePage = () => {
   };
 
   return (
-    <div style={containerStyle}>
-      <h1 style={headerStyle}>Resumen General</h1>
+    <>
+      <div style={containerStyle}>
+        <h1 style={headerStyle}>Resumen General</h1>
 
-      <CalendarOverview />
-      <WeightOverview />
-      <DietOverview />
-    </div>
+        <CalendarOverview />
+        <WeightOverview />
+        <DietOverview />
+      </div>
+      <QuienesSomos />
+      <CoreBusiness />
+      <PropuestaValor />
+    </>
   );
 };
 

--- a/src/components/CoreBusiness.js
+++ b/src/components/CoreBusiness.js
@@ -1,0 +1,48 @@
+'use client';
+import FadeInSection from './FadeInSection';
+
+const CoreBusiness = () => {
+  const sectionStyle = {
+    backgroundImage: "url('https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1600&q=80')",
+    backgroundAttachment: 'fixed',
+    backgroundPosition: 'center',
+    backgroundSize: 'cover',
+    padding: '100px 20px',
+    color: 'white',
+    textAlign: 'center',
+  };
+
+  const overlayStyle = {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: '50px',
+  };
+
+  const listStyle = {
+    listStyle: 'none',
+    padding: 0,
+    marginTop: '20px',
+  };
+
+  return (
+    <section style={sectionStyle}>
+      <div style={overlayStyle}>
+        <FadeInSection>
+          <h2>Core Business</h2>
+        </FadeInSection>
+        <ul style={listStyle}>
+          <FadeInSection delay={100}>
+            <li>Desarrollo de programas personalizados</li>
+          </FadeInSection>
+          <FadeInSection delay={200}>
+            <li>Asesoramiento nutricional</li>
+          </FadeInSection>
+          <FadeInSection delay={300}>
+            <li>Seguimiento de progreso continuo</li>
+          </FadeInSection>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default CoreBusiness;

--- a/src/components/FadeInSection.js
+++ b/src/components/FadeInSection.js
@@ -1,0 +1,37 @@
+'use client';
+import { useRef, useEffect, useState } from 'react';
+
+const FadeInSection = ({ children, delay = 0 }) => {
+  const domRef = useRef(null);
+  const [isVisible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => setVisible(entry.isIntersecting));
+    });
+    const current = domRef.current;
+    if (current) {
+      observer.observe(current);
+    }
+    return () => {
+      if (current) {
+        observer.unobserve(current);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      ref={domRef}
+      style={{
+        opacity: isVisible ? 1 : 0,
+        transform: isVisible ? 'none' : 'translateY(20px)',
+        transition: `opacity 0.6s ease-out ${delay}ms, transform 0.6s ease-out ${delay}ms`,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default FadeInSection;

--- a/src/components/PropuestaValor.js
+++ b/src/components/PropuestaValor.js
@@ -1,0 +1,48 @@
+'use client';
+import FadeInSection from './FadeInSection';
+
+const PropuestaValor = () => {
+  const sectionStyle = {
+    backgroundImage: "url('https://images.unsplash.com/photo-1518609878373-06d740f60d8b?auto=format&fit=crop&w=1600&q=80')",
+    backgroundAttachment: 'fixed',
+    backgroundPosition: 'center',
+    backgroundSize: 'cover',
+    padding: '100px 20px',
+    color: 'white',
+    textAlign: 'center',
+  };
+
+  const overlayStyle = {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: '50px',
+  };
+
+  const listStyle = {
+    listStyle: 'none',
+    padding: 0,
+    marginTop: '20px',
+  };
+
+  return (
+    <section style={sectionStyle}>
+      <div style={overlayStyle}>
+        <FadeInSection>
+          <h2>Propuesta de Valor</h2>
+        </FadeInSection>
+        <ul style={listStyle}>
+          <FadeInSection delay={100}>
+            <li>Resultados medibles en 90 días</li>
+          </FadeInSection>
+          <FadeInSection delay={200}>
+            <li>Acompañamiento integral</li>
+          </FadeInSection>
+          <FadeInSection delay={300}>
+            <li>Soporte profesional 24/7</li>
+          </FadeInSection>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default PropuestaValor;

--- a/src/components/QuienesSomos.js
+++ b/src/components/QuienesSomos.js
@@ -1,0 +1,82 @@
+'use client';
+import { FaUsers, FaAward } from 'react-icons/fa';
+import { useState, useEffect } from 'react';
+import FadeInSection from './FadeInSection';
+
+const AnimatedCounter = ({ target }) => {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let current = 0;
+    const step = target / 50;
+    const interval = setInterval(() => {
+      current += step;
+      if (current >= target) {
+        current = target;
+        clearInterval(interval);
+      }
+      setCount(Math.floor(current));
+    }, 30);
+    return () => clearInterval(interval);
+  }, [target]);
+
+  return <span>{count}+</span>;
+};
+
+const QuienesSomos = () => {
+  const sectionStyle = {
+    backgroundImage: "url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80')",
+    backgroundAttachment: 'fixed',
+    backgroundPosition: 'center',
+    backgroundSize: 'cover',
+    padding: '100px 20px',
+    color: 'white',
+    textAlign: 'center',
+  };
+
+  const overlayStyle = {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: '50px',
+  };
+
+  const metricsStyle = {
+    display: 'flex',
+    justifyContent: 'center',
+    gap: '40px',
+    marginTop: '20px',
+    flexWrap: 'wrap',
+  };
+
+  return (
+    <section style={sectionStyle}>
+      <div style={overlayStyle}>
+        <FadeInSection>
+          <h2>¿Quiénes Somos?</h2>
+        </FadeInSection>
+        <FadeInSection delay={100}>
+          <p>Somos una empresa comprometida con el bienestar y la salud.</p>
+        </FadeInSection>
+        <div style={metricsStyle}>
+          <FadeInSection delay={200}>
+            <div>
+              <FaAward size={40} />
+              <div style={{ fontSize: '24px', fontWeight: 'bold' }}>
+                <AnimatedCounter target={25} /> años
+              </div>
+            </div>
+          </FadeInSection>
+          <FadeInSection delay={300}>
+            <div>
+              <FaUsers size={40} />
+              <div style={{ fontSize: '24px', fontWeight: 'bold' }}>
+                <AnimatedCounter target={100} /> clientes
+              </div>
+            </div>
+          </FadeInSection>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default QuienesSomos;


### PR DESCRIPTION
## Summary
- add `QuienesSomos`, `CoreBusiness` and `PropuestaValor` sections with parallax backgrounds
- introduce animated counters and icons in `QuienesSomos`
- create `FadeInSection` to fade titles and lists into view with delays

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb9ffff38832faf8143b5d2535827