### PR TITLE
feat: embed videos with hover effects and scroll animations

### DIFF
--- a/src/components/ProduccionesDestacadas.js
+++ b/src/components/ProduccionesDestacadas.js
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import styles from './ProduccionesDestacadas.module.css';
+
+const videos = [
+  { id: 1, src: 'https://www.youtube.com/embed/dQw4w9WgXcQ', title: 'Video 1' },
+  { id: 2, src: 'https://www.youtube.com/embed/oHg5SJYRHA0', title: 'Video 2' },
+  { id: 3, src: 'https://www.youtube.com/embed/3GwjfUFyY6M', title: 'Video 3' },
+];
+
+export default function ProduccionesDestacadas() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add(styles.visible);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+
+    const items = Array.from(container.children);
+    items.forEach((item) => observer.observe(item));
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      {videos.map((video) => (
+        <div key={video.id} className={styles.item}>
+          <iframe
+            className={styles.video}
+            src={video.src}
+            title={video.title}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+          <div className={styles.overlay}>▶</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProduccionesDestacadas.module.css
+++ b/src/components/ProduccionesDestacadas.module.css
@@ -1,0 +1,53 @@
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.item {
+  position: relative;
+  width: 320px;
+  height: 180px;
+  overflow: hidden;
+  border-radius: 8px;
+  transform: scale(0.9);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.visible {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  font-size: 2rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.item:hover .video {
+  transform: scale(1.05);
+}
+
+.item:hover .overlay {
+  opacity: 1;
+}

--- a/src/components/SeriesVerticales.js
+++ b/src/components/SeriesVerticales.js
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import styles from './SeriesVerticales.module.css';
+
+const series = [
+  { id: 1, src: 'https://www.youtube.com/embed/dQw4w9WgXcQ', title: 'Serie 1' },
+  { id: 2, src: 'https://www.youtube.com/embed/oHg5SJYRHA0', title: 'Serie 2' },
+  { id: 3, src: 'https://www.youtube.com/embed/3GwjfUFyY6M', title: 'Serie 3' },
+];
+
+export default function SeriesVerticales() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add(styles.visible);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+
+    const items = Array.from(container.children);
+    items.forEach((item) => observer.observe(item));
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      {series.map((video) => (
+        <div key={video.id} className={styles.item}>
+          <iframe
+            className={styles.video}
+            src={video.src}
+            title={video.title}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+          <div className={styles.overlay}>▶</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/SeriesVerticales.module.css
+++ b/src/components/SeriesVerticales.module.css
@@ -1,0 +1,53 @@
+.container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  justify-items: center;
+}
+
+.item {
+  position: relative;
+  width: 200px;
+  height: 350px;
+  overflow: hidden;
+  border-radius: 8px;
+  transform: scale(0.95);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.visible {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  font-size: 2rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.item:hover .video {
+  transform: scale(1.05);
+}
+
+.item:hover .overlay {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- replace placeholder divs with embedded video players for featured productions and vertical series
- enlarge video tiles with hover zoom and play overlay
- animate video tiles into view using IntersectionObserver

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb9fdaab8832fabcd6d9c1f802ca5