### PR TITLE
Use branded media assets

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -26,7 +26,7 @@ export default function Hero({ lang = 'es' }) {
         muted
         loop
         playsInline
-        src="https://videos.pexels.com/video-files/1526908/1526908-uhd_2560_1440_25fps.mp4"
+        src="/Logo Animado.mp4"
       />
       <div className={styles.overlay}>
         <h1 className={styles.title}>{t.title}</h1>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -2,12 +2,12 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import {
   FaInstagram,
   FaEnvelope,
   FaGlobe,
-  FaRegLightbulb,
   FaBars,
   FaTimes,
 } from 'react-icons/fa';
@@ -69,8 +69,14 @@ export default function NavBar({ lang = 'es' }) {
   return (
     <nav className={styles.nav}>
       <Link href={p.home} className={styles.logo}>
-        <FaRegLightbulb className={styles.logoIcon} />
-        <span className={styles.logoText}>LIGHT CHANNEL</span>
+        <Image
+          src="/Logo Light Channel.png"
+          alt="Light Channel"
+          width={160}
+          height={40}
+          priority
+          className={styles.logoImage}
+        />
       </Link>
       <button
         className={styles.menuToggle}

--- a/src/components/NavBar.module.css
+++ b/src/components/NavBar.module.css
@@ -31,18 +31,12 @@
   .logo {
     display: flex;
     align-items: center;
-    color: var(--foreground);
     text-decoration: none;
-    letter-spacing: 2px;
-    font-weight: 700;
   }
 
-.logoIcon {
-  margin-right: 0.5rem;
-}
-
-.logoText {
-  font-size: 1.2rem;
+.logoImage {
+  height: 40px;
+  width: auto;
 }
 
 .links {


### PR DESCRIPTION
## Summary
- Replace navbar text logo with branded image
- Play local animated logo on home hero background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c224925c832f8806de6990dbb639