### PR TITLE
feat: add optimized video playback

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,26 +1,25 @@
 "use client";
-import { useEffect, useRef } from 'react';
-import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
 import styles from './Hero.module.css';
+import VideoModal from './VideoModal';
 
 const content = {
   es: {
     title: 'Light Channel',
     tagline: 'Producción sin límites',
     cta: 'Ver trabajo',
-    ctaLink: '/work',
   },
   en: {
     title: 'Light Channel',
     tagline: 'Production without limits',
     cta: 'See work',
-    ctaLink: '/en/work',
   },
 };
 
 export default function Hero({ lang = 'es' }) {
   const t = content[lang];
   const videoRef = useRef(null);
+  const [showReel, setShowReel] = useState(false);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -53,10 +52,20 @@ export default function Hero({ lang = 'es' }) {
       <div className={styles.overlay}>
         <h1 className={styles.title}>{t.title}</h1>
         <p className={styles.tagline}>{t.tagline}</p>
-        <Link href={t.ctaLink} className={styles.cta}>
+        <button
+          type="button"
+          onClick={() => setShowReel(true)}
+          className={styles.cta}
+        >
           {t.cta}
-        </Link>
+        </button>
       </div>
+      {showReel && (
+        <VideoModal
+          src="/VideoReel.mp4"
+          onClose={() => setShowReel(false)}
+        />
+      )}
     </section>
   );
 }

--- a/src/components/ProduccionesDestacadas.js
+++ b/src/components/ProduccionesDestacadas.js
@@ -1,5 +1,8 @@
+"use client";
 import Image from 'next/image';
+import { useState } from 'react';
 import styles from './ProduccionesDestacadas.module.css';
+import VideoModal from './VideoModal';
 
 const content = {
   es: {
@@ -8,6 +11,7 @@ const content = {
       {
         title: '“El Reto de Creadores” — YouTube Originals',
         image: 'https://placehold.co/800x450',
+        video: '/VideoOriginal1.mp4',
       },
       {
         title: '“Mamá ya es mi Casa” — TelevisaUnivision',
@@ -29,6 +33,7 @@ const content = {
       {
         title: '“El Reto de Creadores” — YouTube Originals',
         image: 'https://placehold.co/800x450',
+        video: '/VideoOriginal1.mp4',
       },
       {
         title: '“Mamá ya es mi Casa” — TelevisaUnivision',
@@ -48,23 +53,46 @@ const content = {
 
 export default function ProduccionesDestacadas({ lang = 'es' }) {
   const t = content[lang];
+  const [videoSrc, setVideoSrc] = useState(null);
   return (
     <section className={styles.section}>
       <h2 className={styles.title}>{t.title}</h2>
       <ul className={styles.list}>
         {t.items.map((i) => (
           <li key={i.title} className={styles.item}>
-            <Image
-              src={i.image}
-              alt={i.title}
-              className={styles.image}
-              width={800}
-              height={450}
-            />
-            <p>{i.title}</p>
+            {i.video ? (
+              <button
+                type="button"
+                className={styles.button}
+                onClick={() => setVideoSrc(i.video)}
+              >
+                <Image
+                  src={i.image}
+                  alt={i.title}
+                  className={styles.image}
+                  width={800}
+                  height={450}
+                />
+                <p>{i.title}</p>
+              </button>
+            ) : (
+              <>
+                <Image
+                  src={i.image}
+                  alt={i.title}
+                  className={styles.image}
+                  width={800}
+                  height={450}
+                />
+                <p>{i.title}</p>
+              </>
+            )}
           </li>
         ))}
       </ul>
+      {videoSrc && (
+        <VideoModal src={videoSrc} onClose={() => setVideoSrc(null)} />
+      )}
     </section>
   );
 }

--- a/src/components/ProduccionesDestacadas.module.css
+++ b/src/components/ProduccionesDestacadas.module.css
@@ -27,6 +27,16 @@
   border-radius: 12px;
 }
 
+.button {
+  display: block;
+  border: none;
+  padding: 0;
+  background: none;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
+}
+
 .image {
   width: 100%;
   aspect-ratio: 16 / 9;

--- a/src/components/VideoModal.js
+++ b/src/components/VideoModal.js
@@ -1,0 +1,42 @@
+"use client";
+import { useEffect, useRef } from 'react';
+import styles from './VideoModal.module.css';
+
+export default function VideoModal({ src, onClose }) {
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    const video = videoRef.current;
+    if (video) {
+      void video.play();
+    }
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  const handleClose = () => {
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+    }
+    onClose();
+  };
+
+  return (
+    <div className={styles.backdrop} onClick={handleClose}>
+      <video
+        ref={videoRef}
+        src={src}
+        controls
+        preload="metadata"
+        className={styles.video}
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/src/components/VideoModal.module.css
+++ b/src/components/VideoModal.module.css
@@ -1,0 +1,15 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.video {
+  max-width: 90vw;
+  max-height: 90vh;
+  background: #000;
+}

--- a/src/components/VirtualProduction.js
+++ b/src/components/VirtualProduction.js
@@ -90,9 +90,10 @@ export default function VirtualProduction({ lang = 'es' }) {
           </ul>
         </div>
         <video
-          src="https://www.w3schools.com/html/mov_bbb.mp4"
+          src="/VideoVS.mp4"
           className={styles.video}
           controls
+          preload="metadata"
         />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- play VideoReel.mp4 in a modal from the home hero CTA
- enable VideoOriginal1.mp4 playback from "El Reto de Creadores" entry
- swap Virtual Production clip for VideoVS.mp4

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62027b76c832fad1e123813eae3d8