### PR TITLE
feat: add video preview thumbnails

### DIFF
--- a/src/components/ProduccionesDestacadas.js
+++ b/src/components/ProduccionesDestacadas.js
@@ -66,13 +66,22 @@ export default function ProduccionesDestacadas({ lang = 'es' }) {
                 className={styles.button}
                 onClick={() => setVideoSrc(i.video)}
               >
-                <Image
-                  src={i.image}
-                  alt={i.title}
+                <video
+                  src={i.video}
+                  poster={i.image}
                   className={styles.image}
                   width={800}
                   height={450}
+                  muted
+                  loop
+                  playsInline
+                  onMouseEnter={(e) => e.currentTarget.play()}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.pause();
+                    e.currentTarget.currentTime = 0;
+                  }}
                 />
+                <span className={styles.playIcon}>▶</span>
                 <p>{i.title}</p>
               </button>
             ) : (

--- a/src/components/ProduccionesDestacadas.module.css
+++ b/src/components/ProduccionesDestacadas.module.css
@@ -35,6 +35,7 @@
   color: inherit;
   text-align: inherit;
   cursor: pointer;
+  position: relative;
 }
 
 .image {
@@ -43,6 +44,16 @@
   object-fit: cover;
   margin-bottom: 1rem;
   display: block;
+}
+
+.playIcon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 3rem;
+  color: white;
+  pointer-events: none;
 }
 
 .item p {


### PR DESCRIPTION
## Summary
- show a hoverable video preview thumbnail in featured productions
- style play icon overlay for video previews

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62542423c832fbb2f64a73f0ca24c