### PR TITLE
Revise hero CTA and naming

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,25 +1,55 @@
 "use client";
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
 import styles from './Hero.module.css';
-import VideoModal from './VideoModal';
 
 const content = {
   es: {
     title: 'Light Channel',
-    tagline: 'Producción sin límites',
-    cta: 'Ver trabajo',
+    tagline: 'Producción sin límites para cine y TV',
+    cta: 'Ver portafolio',
+    ctaHref: '/contenido',
+    logos: [
+      {
+        src: 'https://placehold.co/100x50?text=Cliente+1',
+        alt: 'Cliente 1',
+      },
+      {
+        src: 'https://placehold.co/100x50?text=Cliente+2',
+        alt: 'Cliente 2',
+      },
+      {
+        src: 'https://placehold.co/100x50?text=Cliente+3',
+        alt: 'Cliente 3',
+      },
+    ],
   },
   en: {
     title: 'Light Channel',
-    tagline: 'Production without limits',
-    cta: 'See work',
+    tagline: 'Production without limits for film and TV',
+    cta: 'View portfolio',
+    ctaHref: '/en/original-content',
+    logos: [
+      {
+        src: 'https://placehold.co/100x50?text=Client+1',
+        alt: 'Client 1',
+      },
+      {
+        src: 'https://placehold.co/100x50?text=Client+2',
+        alt: 'Client 2',
+      },
+      {
+        src: 'https://placehold.co/100x50?text=Client+3',
+        alt: 'Client 3',
+      },
+    ],
   },
 };
 
 export default function Hero({ lang = 'es' }) {
   const t = content[lang];
   const videoRef = useRef(null);
-  const [showReel, setShowReel] = useState(false);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -52,20 +82,22 @@ export default function Hero({ lang = 'es' }) {
       <div className={styles.overlay}>
         <h1 className={styles.title}>{t.title}</h1>
         <p className={styles.tagline}>{t.tagline}</p>
-        <button
-          type="button"
-          onClick={() => setShowReel(true)}
-          className={styles.cta}
-        >
+        <Link href={t.ctaHref} className={styles.cta}>
           {t.cta}
-        </button>
+        </Link>
+        <div className={styles.logos}>
+          {t.logos.map((logo) => (
+            <Image
+              key={logo.src}
+              src={logo.src}
+              alt={logo.alt}
+              width={100}
+              height={50}
+              className={styles.logo}
+            />
+          ))}
+        </div>
       </div>
-      {showReel && (
-        <VideoModal
-          src="/VideoReel.mp4"
-          onClose={() => setShowReel(false)}
-        />
-      )}
     </section>
   );
 }

--- a/src/components/Hero.module.css
+++ b/src/components/Hero.module.css
@@ -52,3 +52,17 @@
 .cta:hover {
   background: var(--primary);
 }
+
+.logos {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.logo {
+  width: auto;
+  height: auto;
+  max-width: 100px;
+}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -18,7 +18,7 @@ const labels = {
     home: 'Home',
     about: 'Sobre nosotros',
     original: 'Contenido original',
-    virtual: 'Virtual Production',
+    virtual: 'Producción Virtual',
     services: 'Servicios de Producción',
     team: 'Equipo',
     contact: 'Contacto',

--- a/src/components/VirtualProduction.js
+++ b/src/components/VirtualProduction.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 const content = {
   es: {
-    title: 'Virtual Production',
+    title: 'Producción Virtual',
     intro:
       'Combinamos escenarios digitales y pantallas LED para rodajes flexibles que mantienen la esencia de tu historia.',
     categories: [


### PR DESCRIPTION
## Summary
- Update hero copy and CTA to link directly to the portfolio and display client logo placeholders.
- Rename Spanish navigation and page titles from "Virtual Production" to "Producción Virtual" for consistency.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a67d3eb9a4832fb39397b4c6eeb282